### PR TITLE
Allow optional configuration for "status-first" ordering in all phases. 

### DIFF
--- a/src/task4feedback/simulator/interface.py
+++ b/src/task4feedback/simulator/interface.py
@@ -28,7 +28,8 @@ class SimulatorConfig:
     randomizer: Randomizer = field(default_factory=Randomizer)
     watcher: Watcher = field(default_factory=Watcher)
     mapper: TaskMapper = field(default_factory=TaskMapper)
-    use_eviction: bool = True
+    use_eviction: bool = False  # TODO: Eviction is now deprecated with ready-first
+    order_config: OrderConfig = field(default_factory=OrderConfig)
     task_order_mode: TaskOrderType = TaskOrderType.DEFAULT
     use_duration_noise: bool = False
     noise_scale: float = 0
@@ -60,6 +61,7 @@ def create_simulator(config: SimulatorConfig):
         watcher=config.watcher,
         mapper=config.mapper,
         use_eviction=config.use_eviction,
+        order_config=config.order_config,
         task_order_mode=config.task_order_mode,
         use_duration_noise=config.use_duration_noise,
         noise_scale=config.noise_scale,
@@ -72,9 +74,11 @@ def create_simulator(config: SimulatorConfig):
     )
 
     tasklist, simulated_tasks = create_sim_graph(
-        config.tasks, config.data, use_data=config.use_data,
+        config.tasks,
+        config.data,
+        use_data=config.use_data,
         task_order_mode=config.task_order_mode,
-        task_order_log=config.task_order_log
+        task_order_log=config.task_order_log,
     )
 
     # for task in simulated_tasks.values():

--- a/src/task4feedback/simulator/schedulers/architecture.py
+++ b/src/task4feedback/simulator/schedulers/architecture.py
@@ -21,10 +21,19 @@ from copy import copy, deepcopy
 
 
 @dataclass(slots=True)
+class OrderConfig:
+    mappable: bool = False
+    reservable: bool = False
+    launchable: bool = False
+    apply_sort: bool = False
+
+
+@dataclass(slots=True)
 class SchedulerArchitecture:
     topology: SimulatedTopology
     completed_tasks: List[TaskID] = field(default_factory=list)
-    use_eviction: bool = True
+    use_eviction: bool = False  # TODO: Eviction is now deprecated with ready-first
+    order_config: OrderConfig = field(default_factory=OrderConfig)
 
     def __deepcopy__(self, memo):
         return SchedulerArchitecture(

--- a/src/task4feedback/simulator/schedulers/architecture.py
+++ b/src/task4feedback/simulator/schedulers/architecture.py
@@ -24,7 +24,7 @@ from copy import copy, deepcopy
 class OrderConfig:
     mappable: bool = False
     reservable: bool = False
-    launchable: bool = False
+    launchable: bool = True
     apply_sort: bool = False
 
 

--- a/src/task4feedback/simulator/schedulers/parla/architecture.py
+++ b/src/task4feedback/simulator/schedulers/parla/architecture.py
@@ -574,16 +574,23 @@ class ParlaArchitecture(SchedulerArchitecture):
         Append an initial task who does not have any dependency to
         a spawned task queue.
         """
-        # print(f"Number of tasks: {len(tasks)}")
+        objects = scheduler_state.objects
+        current_time = scheduler_state.time
         for task in tasks:
-            # print(">> task:", task.name)
-            self.spawned_tasks.put(task)
+            if self.order_config.mappable:
+                if check_status := task.check_status(
+                    TaskStatus.MAPPABLE, objects.taskmap, current_time
+                ):
+                    self.mappable_tasks.put(task)
+
+            else:
+                self.mappable_tasks.put(task)
 
     def mapper(
         self, scheduler_state: SystemState, event: Mapper, **kwargs
     ) -> List[EventPair]:
         self.success_count = 0
-        next_tasks = TaskIterator(self.spawned_tasks)
+        next_tasks = TaskIterator(self.mappable_tasks)
 
         # print(f"Running MAPPER at time {scheduler_state.time}")
 
@@ -592,6 +599,14 @@ class ParlaArchitecture(SchedulerArchitecture):
 
         current_time = scheduler_state.time
         objects = scheduler_state.objects
+
+        mappable_first = self.order_config.mappable
+        reservable_first = self.order_config.reservable
+
+        if mappable_first:
+            task_queue = self.mappable_tasks
+        else:
+            task_queue = None
 
         if logger.ENABLE_LOGGING:
             logger.runtime.info(
@@ -604,21 +619,35 @@ class ParlaArchitecture(SchedulerArchitecture):
 
             if not task_mapper.check_allowed(task):
                 # print(f"Task {task.name} not allowed. Draining task.")
-                task.notify_state(TaskState.MAPPED, objects.taskmap, current_time)
+                task.notify_state(
+                    TaskState.MAPPED,
+                    objects.taskmap,
+                    current_time,
+                    next_pool=task_queue,
+                )
                 next_tasks.success()
                 self.success_count += 1
             elif devices := map_task(simulator, task):
-                for device in devices:
-                    self.reservable_tasks[device].put_id(
-                        task_id=taskid, priority=priority
-                    )
+                # print(f"Task {task.name} mapped successfully.", task.status)
+                if (not reservable_first) or task.check_status(
+                    TaskStatus.RESERVABLE, objects.taskmap, current_time
+                ):
+                    for device in devices:
+                        self.reservable_tasks[device].put_id(
+                            task_id=taskid, priority=priority
+                        )
                 if logger.ENABLE_LOGGING:
                     logger.runtime.info(
                         f"Task {task.name}, mapped successfully.",
                         extra=dict(task=taskid, device=devices),
                     )
                 event.tasks.add(taskid)
-                task.notify_state(TaskState.MAPPED, objects.taskmap, current_time)
+                task.notify_state(
+                    TaskState.MAPPED,
+                    objects.taskmap,
+                    current_time,
+                    next_pool=task_queue,
+                )
                 next_tasks.success()
                 self.success_count += 1
 
@@ -666,6 +695,8 @@ class ParlaArchitecture(SchedulerArchitecture):
         assert objects is not None
         assert task.assigned_devices is not None
 
+        launchable_first = self.order_config.launchable
+
         if task.data_tasks is not None:
             for data_task_id in task.data_tasks:
                 data_task: SimulatedDataTask = objects.get_task(data_task_id)  # type: ignore
@@ -706,16 +737,18 @@ class ParlaArchitecture(SchedulerArchitecture):
                 data_task.set_state(
                     TaskState.RESERVED, scheduler_state.time, verify=False
                 )
-                data_task.set_status(
-                    TaskStatus.RESERVABLE, scheduler_state.time, verify=False
-                )
                 # self._add_eviction_dependencies(data_task, scheduler_state)
 
-                data_task.in_ready_queue = True
-
-                self.launchable_tasks[device][TaskType.DATA].put_id(
-                    task_id=data_task_id, priority=task.priority
-                )
+                if (not launchable_first) or (
+                    data_task.check_status(
+                        TaskStatus.LAUNCHABLE, objects.taskmap, scheduler_state.time
+                    )
+                ):
+                    # TODO: This is used for eviction purposes (need to refactor with the ready-first policy)
+                    data_task.in_ready_queue = True
+                    self.launchable_tasks[device][TaskType.DATA].put_id(
+                        task_id=data_task_id, priority=task.priority
+                    )
                 scheduler_state.reserved_active_tasks += 1
                 scheduler_state.mapped_active_tasks += 1
 
@@ -735,6 +768,14 @@ class ParlaArchitecture(SchedulerArchitecture):
                 extra=dict(time=current_time, phase=TaskState.RESERVED),
             )
 
+        reservable_first = self.order_config.reservable
+        launchable_first = self.order_config.launchable
+
+        if reservable_first:
+            task_queue = self.reservable_tasks
+        else:
+            task_queue = None
+
         next_tasks = MultiTaskIterator(self.reservable_tasks)
         for priority, taskid in next_tasks:
             task = objects.get_task(taskid)
@@ -746,7 +787,7 @@ class ParlaArchitecture(SchedulerArchitecture):
             reserve_success, eviction_event = reserve_task(task, scheduler_state)
 
             if reserve_success is True:
-                # print(task, " reserved [done]")
+                # print(f"Task {taskid} reserved successfully.", task.status)
                 devices = task.assigned_devices
                 assert devices is not None
                 device = devices[0]
@@ -762,10 +803,20 @@ class ParlaArchitecture(SchedulerArchitecture):
                 # print(task.dependencies)
                 # print(task.counters)
 
-                task.in_ready_queue = True
-                self.launchable_tasks[device][TaskType.COMPUTE].put_id(
-                    task_id=taskid, priority=priority
-                )
+                if (not launchable_first) or (
+                    task.check_status(
+                        TaskStatus.LAUNCHABLE, objects.taskmap, current_time
+                    )
+                ):
+                    # print(
+                    #     f"Task {taskid} is launchable, adding to launchable queue in reserver.",
+                    #     task.status,
+                    # )
+                    task.in_ready_queue = True
+                    self.launchable_tasks[device][TaskType.COMPUTE].put_id(
+                        task_id=taskid, priority=priority
+                    )
+
                 if logger.ENABLE_LOGGING:
                     logger.runtime.info(
                         f"Task {taskid} reserved successfully.",
@@ -773,7 +824,12 @@ class ParlaArchitecture(SchedulerArchitecture):
                     )
                 event.tasks.add(taskid)
                 # print(f"Task {taskid} reserved successfully.")
-                task.notify_state(TaskState.RESERVED, objects.taskmap, current_time)
+                task.notify_state(
+                    TaskState.RESERVED,
+                    objects.taskmap,
+                    current_time,
+                    next_pool=task_queue,
+                )
                 next_tasks.success()
                 self.success_count += 1
 
@@ -807,11 +863,12 @@ class ParlaArchitecture(SchedulerArchitecture):
             # print(device, eviction_task)
             task_i = objects.get_task(eviction_task)
 
-            task_i.in_ready_queue = True
-
-            self.launchable_tasks[device][TaskType.DATA].put_id(
-                task_id=eviction_task, priority=0
-            )
+            # TODO: This is BROKEN
+            if TaskStatus.LAUNCHABLE in task_i.status:
+                task_i.in_ready_queue = True
+                self.launchable_tasks[device][TaskType.DATA].put_id(
+                    task_id=eviction_task, priority=0
+                )
             scheduler_state.mapped_active_tasks += 1
             scheduler_state.reserved_active_tasks += 1
 
@@ -842,7 +899,7 @@ class ParlaArchitecture(SchedulerArchitecture):
             task = objects.get_task(taskid)
             assert task is not None
 
-            # print(task, " launched")
+            # print(f"Attempting to launch task {taskid}.")
             # Process LAUNCHABLE state
             if launch_success := launch_task(task, scheduler_state):
                 # print("Notifying launched state for task ", taskid)
@@ -929,6 +986,11 @@ class ParlaArchitecture(SchedulerArchitecture):
         task = objects.get_task(event.task)
         current_time = scheduler_state.time
 
+        if self.order_config.launchable:
+            task_queue = self.launchable_tasks
+        else:
+            task_queue = None
+
         if logger.ENABLE_LOGGING:
             # print(f"Completing task {event.task}")
             logger.runtime.critical(
@@ -944,7 +1006,12 @@ class ParlaArchitecture(SchedulerArchitecture):
         complete_task(task, scheduler_state)
 
         # Update status of dependencies
-        task.notify_state(TaskState.COMPLETED, objects.taskmap, scheduler_state.time)
+        task.notify_state(
+            TaskState.COMPLETED,
+            objects.taskmap,
+            scheduler_state.time,
+            next_pool=task_queue,
+        )
 
         self.success_count += 1
         if self.active_scheduler == 0:
@@ -955,7 +1022,7 @@ class ParlaArchitecture(SchedulerArchitecture):
         return next_events
 
     def complete(self, scheduler_state: SystemState, **kwargs) -> bool:
-        complete_flag = self.spawned_tasks.empty()
+        complete_flag = self.mappable_tasks.empty()
         # print("spawned tasks:", self.spawned_tasks)
         for device in self.reservable_tasks:
             complete_flag = complete_flag and self.reservable_tasks[device].empty()

--- a/src/task4feedback/simulator/schedulers/state.py
+++ b/src/task4feedback/simulator/schedulers/state.py
@@ -125,7 +125,7 @@ class SystemState:
     objects: ObjectRegistry | None = None
     time: Time = field(default_factory=Time)
     init: bool = True
-    use_eviction: bool = True
+    use_eviction: bool = False  # TODO: Eviction is now deprecated with ready-first
     use_duration_noise: bool = False
     noise_scale: float = 0
     save_task_order: bool = False

--- a/src/task4feedback/simulator/task.py
+++ b/src/task4feedback/simulator/task.py
@@ -292,7 +292,19 @@ class SimulatedTask:
         taskmap: SimulatedTaskMap,
         time: Time,
         verbose: bool = False,
+        next_pool=None,
     ):
+        """
+        Only notify dependents if the state has changed.
+
+        Loop over all dependents and notify them of the state change.
+        This may change the status of the dependent task.
+        For example, if a task is mapped, the dependent task may become mappable.
+
+        If the dependent task's status changes and it is in the correct state,
+        add it to the next type
+        """
+
         # Notify only if changed
         if self.state == state:
             return
@@ -303,6 +315,7 @@ class SimulatedTask:
         )
 
         for taskid in self.dependents:
+            # The dependent task
             task = taskmap[taskid]
 
             if state in [TaskState.MAPPED, TaskState.RESERVED] and isinstance(
@@ -312,6 +325,29 @@ class SimulatedTask:
 
             if new_status := task.counters.notified_state(state):
                 task.notify_status(new_status, taskmap, time)
+
+                if next_pool is not None:
+
+                    # The status of the dependent task has changed, we need to check if it can be added to the next task queue
+                    dependent_state = task.state
+
+                    # Note: the state implies the previous states
+                    # MAPPED -> SPAWNED, RESERVED -> MAPPED, LAUNCHED -> RESERVED
+
+                    if new_status == TaskStatus.MAPPABLE:
+                        # The task is becomming mappable, ensure that it is SPAWNED
+                        if dependent_state == TaskState.SPAWNED:
+                            next_pool.put(task)
+                    elif new_status == TaskStatus.RESERVABLE:
+                        # The task is becomming reservable, ensure that it is MAPPED
+                        if dependent_state == TaskState.MAPPED:
+                            for device in task.assigned_devices:
+                                next_pool[device].put(task)
+                    elif new_status == TaskStatus.LAUNCHABLE:
+                        # The task is becomming launchable, ensure that it is RESERVED
+                        if dependent_state == TaskState.RESERVED:
+                            for device in task.assigned_devices:
+                                next_pool[device][task.type].put(task)
 
         self.set_state(state, time)
 
@@ -386,6 +422,9 @@ class SimulatedTask:
         #     self.eviction_tasks = []
         # self.eviction_tasks.append(task.name)
 
+    def __lt__(self, __other: SimulatedTask):
+        return self.priority < __other.priority
+
 
 @dataclass(slots=True)
 class SimulatedComputeTask(SimulatedTask):
@@ -440,7 +479,10 @@ class SimulatedComputeTask(SimulatedTask):
 @dataclass(slots=True)
 class SimulatedDataTask(SimulatedTask):
     type: TaskType = TaskType.DATA
-    state: TaskState = TaskState.RESERVED
+    state: TaskState = TaskState.MAPPED
+    status: Set[TaskStatus] = field(
+        default_factory=lambda: {TaskStatus.MAPPABLE, TaskStatus.RESERVABLE}
+    )
     source: Optional[Device] = None
     local_index: int = 0
     real: bool = True


### PR DESCRIPTION
Okay that took longer to test and debug than I hoped. I'm sorry this is so late.

I've added an OrderConfig object that sets the "status-first" priority for each phase.

If a status in this config is set to "False", then that corresponding phase will behave as the simulator has in the past. This means that tasks will just be moved from queue to queue in the given priority order. All tasks in each queue are not guaranteed to have their property met. For example the "mappable queue" feeds the mapper, but may contain both mappable and unmappable tasks. It will block until the head task becomes mappable, etc. Likewise for the reservable and launchable queues.

If a status in this config is set to "True" then the phase will have the corresponding behavior. A task will be enqueued into the corresponding status queue only when the condition is met. For example this enforces "order_config.mappable=True" means that the "mappable queue" only contains mappable tasks. Tasks are enqueued as soon as they meet the condition.

The default behavior on the branch is the following:
- Mapper and Reserver work as they do on "rl-state". (order_config.mappable and order_config.reservable are False)
- Launcher only iterates on ready (launchable) tasks. (order_config.launchable is True)

If all options are set to True, then this mimics the behavior of the Parla runtime. 

Note:
- Eviction is currently broken due to these changes. Do not use it on this branch. 