### PR TITLE
Add collective breakpoints. 

### DIFF
--- a/src/backend/include/breakpoints.hpp
+++ b/src/backend/include/breakpoints.hpp
@@ -8,34 +8,109 @@
 
 class Breakpoint {};
 
-class BreakpointManager {
-private:
-  timecount_t max_time = MAX_TIME;
-  std::map<EventType, TaskIDList> breakpoints;
-  volatile bool breakpoint_status = false;
 
-  static bool check_task(TaskIDList &tasks, taskid_t task) {
+class TaskIDGroup {
+protected:
+  TaskIDList tasks;
+
+public:
+  [[nodiscard]] TaskIDList get_tasks() const {
+    return tasks;
+  }
+
+  void add_task(taskid_t task) {
+    tasks.push_back(task);
+  }
+
+  void add_tasks(const TaskIDList &other) {
+    tasks.insert(tasks.end(), other.begin(), other.end());
+  }
+
+  void remove_task(taskid_t task) {
+    tasks.erase(std::remove(tasks.begin(), tasks.end(), task), tasks.end());
+  }
+
+  void clear() {
+    tasks.clear();
+  }
+
+  [[nodiscard]] bool empty() const {
+    return tasks.empty();
+  }
+
+  [[nodiscard]] size_t size() const {
+    return tasks.size();
+  }
+
+  [[nodiscard]] bool contains(taskid_t task) const {
+    return std::find(tasks.begin(), tasks.end(), task) != tasks.end();
+  }
+
+  [[nodiscard]] bool contains_all(const TaskIDList &other) const {
+    return std::ranges::all_of(other, [this](taskid_t task) { return contains(task); });
+  }
+
+  [[nodiscard]] bool contains_any(const TaskIDList &other) const {
+    return std::ranges::any_of(other, [this](taskid_t task) { return contains(task); });
+  }
+
+  [[nodiscard]] bool contains_none(const TaskIDList &other) const {
+    return std::ranges::none_of(other, [this](taskid_t task) { return contains(task); });
+  }
+};
+
+class IndividualTasks : public TaskIDGroup {
+  public:
+    bool check_task(taskid_t task) {
+        if (tasks.empty()) {
+            return false;
+        }
+        bool found = std::find(tasks.begin(), tasks.end(), task) != tasks.end();
+
+        if (found) {
+            tasks.erase(std::remove(tasks.begin(), tasks.end(), task), tasks.end());
+        }
+
+        //If the task is found, then the breakpoint is triggered
+        return found;
+    }
+
+};
+
+class CollectiveTasks : public TaskIDGroup {
+  public: 
+  bool check_task(taskid_t task) {
     if (tasks.empty()) {
       return false;
     }
+
     bool found = std::find(tasks.begin(), tasks.end(), task) != tasks.end();
 
     if (found) {
-      // Remove task from list
       tasks.erase(std::remove(tasks.begin(), tasks.end(), task), tasks.end());
+
+      //If all tasks have been found, then the breakpoint is triggered
+      //Only triggers when the last task is found
+      if (tasks.empty()) {
+        return true;
+      }
+
     }
-    return found;
+
+    return false;
   }
+};
 
-  static bool check_tasks(TaskIDList &tasks, const TaskIDList &other) {
-    if (tasks.empty() || other.empty()) {
-      return false;
-    }
+class BreakpointManager {
+private:
+  timecount_t max_time = MAX_TIME;
+  std::map<EventType, IndividualTasks> breakpoints;
+  std::map<EventType, CollectiveTasks> group_breakpoints;
 
-    return std::ranges::all_of(other, [&tasks](taskid_t task) { return check_task(tasks, task); });
-  }
+  volatile bool breakpoint_status = false;
 
-  static bool check_event(const std::map<EventType, TaskIDList> &map, EventType type) {
+  template<typename T>
+  static bool check_event(const std::map<EventType, T> &map, EventType type) {
     return map.find(type) != map.end();
   }
 
@@ -50,8 +125,14 @@ public:
 
   bool check_task_breakpoint(EventType type, taskid_t task) {
     bool is_breakpoint = check_event(breakpoints, type);
+    bool is_breakpoint_individual = false;
+    bool is_breakpoint_collective = false;
+
     if (is_breakpoint) {
-      is_breakpoint = check_task(breakpoints.at(type), task);
+      is_breakpoint_individual = breakpoints.at(type).check_task(task);
+      is_breakpoint_collective = group_breakpoints.at(type).check_task(task);
+      //both need to run in order to remove triggering tasks 
+      is_breakpoint = is_breakpoint_individual || is_breakpoint_collective;
     }
     if (is_breakpoint) {
       breakpoint_status = true;
@@ -69,10 +150,32 @@ public:
 
   void add_breakpoint(EventType type, taskid_t task) {
     if (!check_event(breakpoints, type)) {
-      breakpoints[type] = TaskIDList();
+      breakpoints[type] = IndividualTasks();
     }
-    breakpoints[type].push_back(task);
+    breakpoints[type].add_task(task);
   }
+
+  void add_breakpoint(EventType type, const TaskIDList &tasks) {
+    if (!check_event(breakpoints, type)) {
+      breakpoints[type] = IndividualTasks();
+    }
+    breakpoints[type].add_tasks(tasks);
+  }
+
+  void add_collective_breakpoint(EventType type, taskid_t task) {
+    if (!check_event(group_breakpoints, type)) {
+      group_breakpoints[type] = CollectiveTasks();
+    }
+    group_breakpoints[type].add_task(task);
+  }
+
+  void add_collective_breakpoint(EventType type, const TaskIDList &tasks) {
+    if (!check_event(group_breakpoints, type)) {
+      group_breakpoints[type] = CollectiveTasks();
+    }
+    group_breakpoints[type].add_tasks(tasks);
+  }
+
 
   void add_time_breakpoint(timecount_t time) {
     max_time = time;

--- a/src/backend/include/simulator.hpp
+++ b/src/backend/include/simulator.hpp
@@ -258,8 +258,12 @@ public:
     return scheduler.get_state().get_global_time();
   }
 
-  void add_task_breakpoint(EventType type, taskid_t task) {
-    scheduler.breakpoints.add_breakpoint(type, task);
+  void add_task_breakpoint(EventType type, taskid_t task, bool collective = false) {
+    if (collective) {
+      scheduler.breakpoints.add_collective_breakpoint(type, task);
+    } else {
+      scheduler.breakpoints.add_breakpoint(type, task);
+    }
   }
 
   void add_time_breakpoint(timecount_t time) {

--- a/src/task4feedback/fastsim/interface.py
+++ b/src/task4feedback/fastsim/interface.py
@@ -865,7 +865,7 @@ class Simulator:
     def add_time_breakpoint(self, time: int):
         self.simulator.add_time_breakpoint(time)
 
-    def add_task_breakpoint(self, event: Phase, task_id: int):
+    def add_task_breakpoint(self, event: Phase, task_id: int, collective: bool = False):
         if event == Phase.MAP:
             etype = PyEventType.MAPPER
         elif event == Phase.RESERVE:
@@ -875,7 +875,7 @@ class Simulator:
         elif event == Phase.COMPLETE:
             etype = PyEventType.COMPLETER
 
-        self.simulator.add_task_breakpoint(etype, task_id)
+        self.simulator.add_task_breakpoint(etype, task_id, collective)
 
     def get_mapping(self, task_index: int) -> int:
         return self.simulator.get_mapping(task_index)

--- a/src/task4feedback/fastsim/simulator.pxd
+++ b/src/task4feedback/fastsim/simulator.pxd
@@ -88,7 +88,7 @@ cdef extern from "include/simulator.hpp":
         timecount_t get_current_time()
         TaskIDList get_mappable_candidates()
         void map_tasks(ActionList& actions)
-        void add_task_breakpoint(EventType event_type, taskid_t task_id)
+        void add_task_breakpoint(EventType event_type, taskid_t task_id, bool collective)
         void add_time_breakpoint(timecount_t time)
         void set_use_python_mapper(bool use_python_mapper)
         void set_mapper(Mapper& mapper)

--- a/src/task4feedback/fastsim/simulator.pyx
+++ b/src/task4feedback/fastsim/simulator.pyx
@@ -637,8 +637,8 @@ cdef class PySimulator:
             action_list.push_back(deref(action_ptr))
         self.simulator.map_tasks(action_list)
 
-    def add_task_breakpoint(self, event_type, taskid_t task_id):
-        self.simulator.add_task_breakpoint(convert_py_event_type(event_type), task_id)
+    def add_task_breakpoint(self, event_type, taskid_t task_id, collective):
+        self.simulator.add_task_breakpoint(convert_py_event_type(event_type), task_id, collective)
 
     def add_time_breakpoint(self, timecount_t time):
         self.simulator.add_time_breakpoint(time)


### PR DESCRIPTION
Allows adding task lists to an event type that specifies a simulator breakpoint when all tasks pass that event type. 

For example:
Breakpoint: <MAP, [Task 0, Task 1, Task2]>

This will pause the simulator when Task 0, Task 1, and Task 2 have been mapped regardless of the order this happens in. 


Currently we do not plan to support collective breakpoints that mix and match event types. 
For example, you cannot say "pause the simulator when Task 0 has been mapped AND Task 1 has been launched". 


